### PR TITLE
Add notebook for LAST-QGAN training

### DIFF
--- a/last_qgan_medmnist.ipynb
+++ b/last_qgan_medmnist.ipynb
@@ -1,0 +1,127 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LAST-QGAN com Autoencoder\n",
+    "\n",
+    "Este notebook combina o treinamento de um autoencoder cl\u00e1ssico com um gerador qu\u00e2ntico. O autoencoder fornece o espa\u00e7o latente onde o QGAN opera.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Instala\u00e7\u00e3o e imports b\u00e1sicos\n",
+    "!pip install pennylane lightning wandb --quiet\n",
+    "import torch\n",
+    "import pennylane as qml\n",
+    "from torch.utils.data import DataLoader\n",
+    "from utils import DigitsDataset, seed_everything\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepara\u00e7\u00e3o do Dataset\n",
+    "Utilizamos o CSV com os d\u00edgitos do MNIST para gerar os lotes de treino.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "dataset = DigitsDataset(path_to_csv='mnist.csv', label=range(10))\n",
+    "dataloader = DataLoader(dataset, batch_size=128, shuffle=True)\n",
+    "len(dataset)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Treinamento do Autoencoder\n",
+    "Carregamos a configura\u00e7\u00e3o do `autoencoder.yaml` e treinamos o modelo cl\u00e1ssico que far\u00e1 a ponte entre as imagens e o espa\u00e7o latente.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Treina o autoencoder conforme definido no YAML\n",
+    "!python train_autoencoder.py -c autoencoder.yaml\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Treinamento do LAST-QGAN\n",
+    "Com o autoencoder j\u00e1 treinado, iniciamos o treinamento do QGAN que gera vetores latentes plaus\u00edveis.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# O caminho para o checkpoint do autoencoder \u00e9 lido de `gan.yaml`\n",
+    "!python train_qgan.py -c gan.yaml -a autoencoder.yaml\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Gera\u00e7\u00e3o de amostras\n",
+    "Ap\u00f3s o treinamento, podemos carregar os pesos e gerar novas imagens a partir de ru\u00eddo qu\u00e2ntico.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from utils import build_model_from_config, AutoencoderModule, GANModule\n",
+    "from train_qgan import QuantumGenerator, Config as QConfig\n",
+    "# Carrega configura\u00e7\u00f5es\n",
+    "with open('gan.yaml') as f:\n",
+    "    gan_cfg = yaml.safe_load(f)\n",
+    "with open('autoencoder.yaml') as f:\n",
+    "    ae_cfg = yaml.safe_load(f)\n",
+    "auto = build_model_from_config(ae_cfg['autoencoder'])\n",
+    "ae_module = AutoencoderModule.load_from_checkpoint(gan_cfg['path_to_autoencoder'], autoencoder=auto, optimizer=ae_cfg['optimizers']).double()\n",
+    "generator = QuantumGenerator(n_qubits=gan_cfg['n_qubits'], n_rots=6, n_circuits=gan_cfg['n_circuits'], dropout=gan_cfg['generator_dropout']).double()\n",
+    "disc = build_model_from_config(gan_cfg['discriminator']).double()\n",
+    "gan = GANModule(autoencoder=ae_module, generator=generator, discriminator=disc, alpha=gan_cfg['alpha'], n_qubits=gan_cfg['n_qubits'], n_rots=6, optimizers_config=gan_cfg['optimizers'], step_disc_every_n_steps=gan_cfg['step_disc_every_n_steps']).double()\n",
+    "noise = gan.noise(5)\n",
+    "samples = gan.generate(noise)\n",
+    "samples.shape\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add Jupyter notebook `last_qgan_medmnist.ipynb` showcasing training pipeline for a classical autoencoder and quantum GAN.
- Notebook loads MNIST CSV data, trains autoencoder, trains LAST-QGAN, and demonstrates sample generation from trained model.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a9b4629cbc8331a83d190f5cf012cc