### PR TITLE
Remove simplified training from quantum GAN notebook

### DIFF
--- a/mosaiq_gan_medmnist.ipynb
+++ b/mosaiq_gan_medmnist.ipynb
@@ -114,94 +114,18 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from torch.utils.data import DataLoader, Subset\n",
-    "\n",
-    "def subset_by_label(dataset, label):\n",
-    "    # suporta datasets que usam .labels ou .targets\n",
-    "    labels = dataset.labels if hasattr(dataset, \"labels\") else dataset.targets\n",
-    "    idx = []\n",
-    "    for i, l in enumerate(labels):\n",
-    "        # extrai o valor escalar de qualquer tensor ou array\n",
-    "        scalar = l.item() if hasattr(l, \"item\") else int(l)\n",
-    "        if scalar == label:\n",
-    "            idx.append(i)\n",
-    "    return Subset(dataset, idx)\n",
-    "\n",
-    "# agora você pode criar os DataLoaders:\n",
-    "train_loader_0 = DataLoader(\n",
-    "    subset_by_label(train_dataset, 0),\n",
-    "    batch_size=batch_size,\n",
-    "    shuffle=True,\n",
-    ")\n",
-    "train_loader_1 = DataLoader(\n",
-    "    subset_by_label(train_dataset, 1),\n",
-    "    batch_size=batch_size,\n",
-    "    shuffle=True,\n",
-    ")\n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 4. Treinamento\n",
-    "Define a função de perda adversarial e executa um ciclo de treinamento simplificado."
+    "Configuração de modelos e funções para treinamento separado por classes."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "cuda\n",
-      "Iter 1/500: Loss D=1.334, Loss G=0.669 — 54.40s\n",
-      "Iter 2/500: Loss D=1.203, Loss G=0.781 — 54.29s\n"
-     ]
-    },
-    {
-     "ename": "KeyboardInterrupt",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[10], line 140\u001b[0m\n\u001b[1;32m    137\u001b[0m fake_lbl \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mzeros((b_size, \u001b[38;5;241m1\u001b[39m), device\u001b[38;5;241m=\u001b[39mdevice)\n\u001b[1;32m    139\u001b[0m noise \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mrand(b_size, n_qubits, device\u001b[38;5;241m=\u001b[39mdevice) \u001b[38;5;241m*\u001b[39m (math\u001b[38;5;241m.\u001b[39mpi \u001b[38;5;241m/\u001b[39m \u001b[38;5;241m2\u001b[39m)\n\u001b[0;32m--> 140\u001b[0m fake  \u001b[38;5;241m=\u001b[39m \u001b[43mG\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnoise\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    142\u001b[0m \u001b[38;5;66;03m# treina Discriminador\u001b[39;00m\n\u001b[1;32m    143\u001b[0m optD\u001b[38;5;241m.\u001b[39mzero_grad()\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/torch/nn/modules/module.py:1511\u001b[0m, in \u001b[0;36mModule._wrapped_call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1509\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_compiled_call_impl(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)  \u001b[38;5;66;03m# type: ignore[misc]\u001b[39;00m\n\u001b[1;32m   1510\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m-> 1511\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_call_impl\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/torch/nn/modules/module.py:1520\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1515\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1516\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1517\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks\n\u001b[1;32m   1518\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1519\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1520\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1522\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m   1523\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n",
-      "Cell \u001b[0;32mIn[10], line 106\u001b[0m, in \u001b[0;36mQuantumGenerator.forward\u001b[0;34m(self, x)\u001b[0m\n\u001b[1;32m    102\u001b[0m images \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mzeros(batch_size, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_generators \u001b[38;5;241m*\u001b[39m n_qubits, device\u001b[38;5;241m=\u001b[39mdevice)\n\u001b[1;32m    104\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m gen_idx, params \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28menumerate\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mq_params):\n\u001b[1;32m    105\u001b[0m     \u001b[38;5;66;03m# para cada amostra, roda o circuito (em CPU) e retorna CPU tensor\u001b[39;00m\n\u001b[0;32m--> 106\u001b[0m     patches \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mstack(\u001b[43m[\u001b[49m\n\u001b[1;32m    107\u001b[0m \u001b[43m        \u001b[49m\u001b[43mtorch\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtensor\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    108\u001b[0m \u001b[43m            \u001b[49m\u001b[43mquantum_circuit\u001b[49m\u001b[43m(\u001b[49m\u001b[43msample\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcpu\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mparams\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcpu\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    109\u001b[0m \u001b[43m            \u001b[49m\u001b[43mdevice\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdevice\u001b[49m\n\u001b[1;32m    110\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfloat\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    111\u001b[0m \u001b[43m        \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43msample\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mx\u001b[49m\n\u001b[1;32m    112\u001b[0m \u001b[43m    \u001b[49m\u001b[43m]\u001b[49m, dim\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m0\u001b[39m)  \u001b[38;5;66;03m# shape (batch_size, n_qubits)\u001b[39;00m\n\u001b[1;32m    114\u001b[0m     start \u001b[38;5;241m=\u001b[39m gen_idx \u001b[38;5;241m*\u001b[39m n_qubits\n\u001b[1;32m    115\u001b[0m     images[:, start:start \u001b[38;5;241m+\u001b[39m n_qubits] \u001b[38;5;241m=\u001b[39m patches\n",
-      "Cell \u001b[0;32mIn[10], line 108\u001b[0m, in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    102\u001b[0m images \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mzeros(batch_size, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_generators \u001b[38;5;241m*\u001b[39m n_qubits, device\u001b[38;5;241m=\u001b[39mdevice)\n\u001b[1;32m    104\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m gen_idx, params \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28menumerate\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mq_params):\n\u001b[1;32m    105\u001b[0m     \u001b[38;5;66;03m# para cada amostra, roda o circuito (em CPU) e retorna CPU tensor\u001b[39;00m\n\u001b[1;32m    106\u001b[0m     patches \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mstack([\n\u001b[1;32m    107\u001b[0m         torch\u001b[38;5;241m.\u001b[39mtensor(\n\u001b[0;32m--> 108\u001b[0m             \u001b[43mquantum_circuit\u001b[49m\u001b[43m(\u001b[49m\u001b[43msample\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcpu\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mparams\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcpu\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m,\n\u001b[1;32m    109\u001b[0m             device\u001b[38;5;241m=\u001b[39mdevice\n\u001b[1;32m    110\u001b[0m         )\u001b[38;5;241m.\u001b[39mfloat()\n\u001b[1;32m    111\u001b[0m         \u001b[38;5;28;01mfor\u001b[39;00m sample \u001b[38;5;129;01min\u001b[39;00m x\n\u001b[1;32m    112\u001b[0m     ], dim\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m0\u001b[39m)  \u001b[38;5;66;03m# shape (batch_size, n_qubits)\u001b[39;00m\n\u001b[1;32m    114\u001b[0m     start \u001b[38;5;241m=\u001b[39m gen_idx \u001b[38;5;241m*\u001b[39m n_qubits\n\u001b[1;32m    115\u001b[0m     images[:, start:start \u001b[38;5;241m+\u001b[39m n_qubits] \u001b[38;5;241m=\u001b[39m patches\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/workflow/qnode.py:922\u001b[0m, in \u001b[0;36mQNode.__call__\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    919\u001b[0m     \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01m_capture_qnode\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m capture_qnode  \u001b[38;5;66;03m# pylint: disable=import-outside-toplevel\u001b[39;00m\n\u001b[1;32m    921\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m capture_qnode(\u001b[38;5;28mself\u001b[39m, \u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n\u001b[0;32m--> 922\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_impl_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/workflow/qnode.py:895\u001b[0m, in \u001b[0;36mQNode._impl_call\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    892\u001b[0m \u001b[38;5;66;03m# Calculate the classical jacobians if necessary\u001b[39;00m\n\u001b[1;32m    893\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_transform_program\u001b[38;5;241m.\u001b[39mset_classical_component(\u001b[38;5;28mself\u001b[39m, args, kwargs)\n\u001b[0;32m--> 895\u001b[0m res \u001b[38;5;241m=\u001b[39m \u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    896\u001b[0m \u001b[43m    \u001b[49m\u001b[43m(\u001b[49m\u001b[43mtape\u001b[49m\u001b[43m,\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    897\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdevice\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdevice\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    898\u001b[0m \u001b[43m    \u001b[49m\u001b[43mdiff_method\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdiff_method\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    899\u001b[0m \u001b[43m    \u001b[49m\u001b[43minterface\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43minterface\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    900\u001b[0m \u001b[43m    \u001b[49m\u001b[43mtransform_program\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_transform_program\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    901\u001b[0m \u001b[43m    \u001b[49m\u001b[43mgradient_kwargs\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mgradient_kwargs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    902\u001b[0m \u001b[43m    \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute_kwargs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    903\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    904\u001b[0m res \u001b[38;5;241m=\u001b[39m res[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    906\u001b[0m \u001b[38;5;66;03m# convert result to the interface in case the qfunc has no parameters\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/workflow/execution.py:233\u001b[0m, in \u001b[0;36mexecute\u001b[0;34m(tapes, device, diff_method, interface, grad_on_execution, cache, cachesize, max_diff, device_vjp, postselect_mode, mcm_method, gradient_kwargs, transform_program, executor_backend)\u001b[0m\n\u001b[1;32m    229\u001b[0m tapes, outer_post_processing \u001b[38;5;241m=\u001b[39m outer_transform(tapes)\n\u001b[1;32m    231\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m outer_transform\u001b[38;5;241m.\u001b[39mis_informative, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mshould only contain device preprocessing\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m--> 233\u001b[0m results \u001b[38;5;241m=\u001b[39m \u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtapes\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mconfig\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43minner_transform\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    234\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m user_post_processing(outer_post_processing(results))\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/workflow/run.py:338\u001b[0m, in \u001b[0;36mrun\u001b[0;34m(tapes, device, config, inner_transform_program)\u001b[0m\n\u001b[1;32m    335\u001b[0m         params \u001b[38;5;241m=\u001b[39m tape\u001b[38;5;241m.\u001b[39mget_parameters(trainable_only\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m)\n\u001b[1;32m    336\u001b[0m         tape\u001b[38;5;241m.\u001b[39mtrainable_params \u001b[38;5;241m=\u001b[39m qml\u001b[38;5;241m.\u001b[39mmath\u001b[38;5;241m.\u001b[39mget_trainable_indices(params)\n\u001b[0;32m--> 338\u001b[0m results \u001b[38;5;241m=\u001b[39m \u001b[43mml_execute\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtapes\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mexecute_fn\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mjpc\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdevice\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdevice\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    339\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m results\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/workflow/interfaces/torch.py:240\u001b[0m, in \u001b[0;36mexecute\u001b[0;34m(tapes, execute_fn, jpc, device)\u001b[0m\n\u001b[1;32m    232\u001b[0m     parameters\u001b[38;5;241m.\u001b[39mextend(tape\u001b[38;5;241m.\u001b[39mget_parameters())\n\u001b[1;32m    234\u001b[0m kwargs \u001b[38;5;241m=\u001b[39m {\n\u001b[1;32m    235\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtapes\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;28mtuple\u001b[39m(tapes),\n\u001b[1;32m    236\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mexecute_fn\u001b[39m\u001b[38;5;124m\"\u001b[39m: execute_fn,\n\u001b[1;32m    237\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mjpc\u001b[39m\u001b[38;5;124m\"\u001b[39m: jpc,\n\u001b[1;32m    238\u001b[0m }\n\u001b[0;32m--> 240\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mExecuteTapes\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mapply\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mparameters\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/workflow/interfaces/torch.py:89\u001b[0m, in \u001b[0;36mpytreeify.<locals>.new_apply\u001b[0;34m(*inp)\u001b[0m\n\u001b[1;32m     86\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mnew_apply\u001b[39m(\u001b[38;5;241m*\u001b[39minp):\n\u001b[1;32m     87\u001b[0m     \u001b[38;5;66;03m# Inputs already flat\u001b[39;00m\n\u001b[1;32m     88\u001b[0m     out_struct_holder \u001b[38;5;241m=\u001b[39m []\n\u001b[0;32m---> 89\u001b[0m     flat_out \u001b[38;5;241m=\u001b[39m \u001b[43morig_apply\u001b[49m\u001b[43m(\u001b[49m\u001b[43mout_struct_holder\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43minp\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     90\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m pytree\u001b[38;5;241m.\u001b[39mtree_unflatten(flat_out, out_struct_holder[\u001b[38;5;241m0\u001b[39m])\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/torch/autograd/function.py:553\u001b[0m, in \u001b[0;36mFunction.apply\u001b[0;34m(cls, *args, **kwargs)\u001b[0m\n\u001b[1;32m    550\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m torch\u001b[38;5;241m.\u001b[39m_C\u001b[38;5;241m.\u001b[39m_are_functorch_transforms_active():\n\u001b[1;32m    551\u001b[0m     \u001b[38;5;66;03m# See NOTE: [functorch vjp and autograd interaction]\u001b[39;00m\n\u001b[1;32m    552\u001b[0m     args \u001b[38;5;241m=\u001b[39m _functorch\u001b[38;5;241m.\u001b[39mutils\u001b[38;5;241m.\u001b[39munwrap_dead_wrappers(args)\n\u001b[0;32m--> 553\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mapply\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m  \u001b[38;5;66;03m# type: ignore[misc]\u001b[39;00m\n\u001b[1;32m    555\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m is_setup_ctx_defined:\n\u001b[1;32m    556\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mRuntimeError\u001b[39;00m(\n\u001b[1;32m    557\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mIn order to use an autograd.Function with functorch transforms \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    558\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m(vmap, grad, jvp, jacrev, ...), it must override the setup_context \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    559\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstaticmethod. For more details, please see \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    560\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhttps://pytorch.org/docs/master/notes/extending.func.html\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    561\u001b[0m     )\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/workflow/interfaces/torch.py:93\u001b[0m, in \u001b[0;36mpytreeify.<locals>.new_forward\u001b[0;34m(ctx, out_struct_holder, *inp)\u001b[0m\n\u001b[1;32m     92\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mnew_forward\u001b[39m(ctx, out_struct_holder, \u001b[38;5;241m*\u001b[39minp):\n\u001b[0;32m---> 93\u001b[0m     out \u001b[38;5;241m=\u001b[39m \u001b[43morig_fw\u001b[49m\u001b[43m(\u001b[49m\u001b[43mctx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43minp\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     94\u001b[0m     flat_out, out_struct \u001b[38;5;241m=\u001b[39m pytree\u001b[38;5;241m.\u001b[39mtree_flatten(out)\n\u001b[1;32m     95\u001b[0m     ctx\u001b[38;5;241m.\u001b[39m_out_struct \u001b[38;5;241m=\u001b[39m out_struct\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/workflow/interfaces/torch.py:162\u001b[0m, in \u001b[0;36mExecuteTapes.forward\u001b[0;34m(ctx, kwargs, *parameters)\u001b[0m\n\u001b[1;32m    159\u001b[0m ctx\u001b[38;5;241m.\u001b[39mtapes \u001b[38;5;241m=\u001b[39m kwargs[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtapes\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[1;32m    160\u001b[0m ctx\u001b[38;5;241m.\u001b[39mjpc \u001b[38;5;241m=\u001b[39m kwargs[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mjpc\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[0;32m--> 162\u001b[0m res \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mtuple\u001b[39m(\u001b[43mkwargs\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mexecute_fn\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m(\u001b[49m\u001b[43mctx\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtapes\u001b[49m\u001b[43m)\u001b[49m)\n\u001b[1;32m    164\u001b[0m \u001b[38;5;66;03m# if any input tensor uses the GPU, the output should as well\u001b[39;00m\n\u001b[1;32m    165\u001b[0m ctx\u001b[38;5;241m.\u001b[39mtorch_device \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/workflow/run.py:253\u001b[0m, in \u001b[0;36m_make_inner_execute.<locals>.inner_execute\u001b[0;34m(tapes)\u001b[0m\n\u001b[1;32m    244\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21minner_execute\u001b[39m(tapes: QuantumScriptBatch) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m ResultBatch:\n\u001b[1;32m    245\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Execution that occurs within a ML framework boundary.\u001b[39;00m\n\u001b[1;32m    246\u001b[0m \n\u001b[1;32m    247\u001b[0m \u001b[38;5;124;03m    Closure Variables:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    250\u001b[0m \u001b[38;5;124;03m        device (qml.devices.Device): a Pennylane device\u001b[39;00m\n\u001b[1;32m    251\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 253\u001b[0m     transformed_tapes, transform_post_processing \u001b[38;5;241m=\u001b[39m \u001b[43minner_transform\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtapes\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    255\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m transformed_tapes:\n\u001b[1;32m    256\u001b[0m         results \u001b[38;5;241m=\u001b[39m device\u001b[38;5;241m.\u001b[39mexecute(transformed_tapes, execution_config\u001b[38;5;241m=\u001b[39mexecution_config)\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/transforms/core/transform_program.py:501\u001b[0m, in \u001b[0;36mTransformProgram.__call__\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    499\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mtype\u001b[39m(args[\u001b[38;5;241m0\u001b[39m])\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mJaxpr\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[1;32m    500\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m__call_jaxpr(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n\u001b[0;32m--> 501\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m__call_tapes\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/transforms/core/transform_program.py:431\u001b[0m, in \u001b[0;36mTransformProgram.__call_tapes\u001b[0;34m(self, tapes)\u001b[0m\n\u001b[1;32m    428\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m argnums \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    429\u001b[0m     \u001b[38;5;66;03m# pylint: disable=unsubscriptable-object\u001b[39;00m\n\u001b[1;32m    430\u001b[0m     tape\u001b[38;5;241m.\u001b[39mtrainable_params \u001b[38;5;241m=\u001b[39m argnums[tape_idx]\n\u001b[0;32m--> 431\u001b[0m new_tapes, fn \u001b[38;5;241m=\u001b[39m \u001b[43mtransform\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtape\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mtargs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mtkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    432\u001b[0m execution_tapes\u001b[38;5;241m.\u001b[39mextend(new_tapes)\n\u001b[1;32m    434\u001b[0m fns\u001b[38;5;241m.\u001b[39mappend(fn)\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/transforms/convert_to_numpy_parameters.py:84\u001b[0m, in \u001b[0;36mconvert_to_numpy_parameters\u001b[0;34m(tape)\u001b[0m\n\u001b[1;32m     82\u001b[0m new_ops \u001b[38;5;241m=\u001b[39m (_convert_op_to_numpy_data(op) \u001b[38;5;28;01mfor\u001b[39;00m op \u001b[38;5;129;01min\u001b[39;00m tape\u001b[38;5;241m.\u001b[39moperations)\n\u001b[1;32m     83\u001b[0m new_measurements \u001b[38;5;241m=\u001b[39m (_convert_measurement_to_numpy_data(m) \u001b[38;5;28;01mfor\u001b[39;00m m \u001b[38;5;129;01min\u001b[39;00m tape\u001b[38;5;241m.\u001b[39mmeasurements)\n\u001b[0;32m---> 84\u001b[0m new_circuit \u001b[38;5;241m=\u001b[39m \u001b[43mtape\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[38;5;18;43m__class__\u001b[39;49m\u001b[43m(\u001b[49m\n\u001b[1;32m     85\u001b[0m \u001b[43m    \u001b[49m\u001b[43mnew_ops\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mnew_measurements\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mshots\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mtape\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshots\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtrainable_params\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mtape\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtrainable_params\u001b[49m\n\u001b[1;32m     86\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     88\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mnull_postprocessing\u001b[39m(results):\n\u001b[1;32m     89\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"A postprocesing function returned by a transform that only converts the batch of results\u001b[39;00m\n\u001b[1;32m     90\u001b[0m \u001b[38;5;124;03m    into a result for a single ``QuantumTape``.\u001b[39;00m\n\u001b[1;32m     91\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/tape/qscript.py:194\u001b[0m, in \u001b[0;36mQuantumScript.__init__\u001b[0;34m(self, ops, measurements, shots, trainable_params)\u001b[0m\n\u001b[1;32m    187\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\n\u001b[1;32m    188\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m    189\u001b[0m     ops: Optional[Iterable[Operator]] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    192\u001b[0m     trainable_params: Optional[Sequence[\u001b[38;5;28mint\u001b[39m]] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    193\u001b[0m ):\n\u001b[0;32m--> 194\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_ops \u001b[38;5;241m=\u001b[39m [] \u001b[38;5;28;01mif\u001b[39;00m ops \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28mlist\u001b[39m(ops)\n\u001b[1;32m    195\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_measurements \u001b[38;5;241m=\u001b[39m [] \u001b[38;5;28;01mif\u001b[39;00m measurements \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28mlist\u001b[39m(measurements)\n\u001b[1;32m    196\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_shots \u001b[38;5;241m=\u001b[39m Shots(shots)\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/transforms/convert_to_numpy_parameters.py:82\u001b[0m, in \u001b[0;36m<genexpr>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m     47\u001b[0m \u001b[38;5;129m@transform\u001b[39m\n\u001b[1;32m     48\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mconvert_to_numpy_parameters\u001b[39m(tape: QuantumScript) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28mtuple\u001b[39m[QuantumScriptBatch, PostprocessingFn]:\n\u001b[1;32m     49\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Transforms a circuit to one with purely numpy parameters.\u001b[39;00m\n\u001b[1;32m     50\u001b[0m \n\u001b[1;32m     51\u001b[0m \u001b[38;5;124;03m    Args:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     80\u001b[0m \n\u001b[1;32m     81\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m---> 82\u001b[0m     new_ops \u001b[38;5;241m=\u001b[39m (\u001b[43m_convert_op_to_numpy_data\u001b[49m\u001b[43m(\u001b[49m\u001b[43mop\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m op \u001b[38;5;129;01min\u001b[39;00m tape\u001b[38;5;241m.\u001b[39moperations)\n\u001b[1;32m     83\u001b[0m     new_measurements \u001b[38;5;241m=\u001b[39m (_convert_measurement_to_numpy_data(m) \u001b[38;5;28;01mfor\u001b[39;00m m \u001b[38;5;129;01min\u001b[39;00m tape\u001b[38;5;241m.\u001b[39mmeasurements)\n\u001b[1;32m     84\u001b[0m     new_circuit \u001b[38;5;241m=\u001b[39m tape\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m(\n\u001b[1;32m     85\u001b[0m         new_ops, new_measurements, shots\u001b[38;5;241m=\u001b[39mtape\u001b[38;5;241m.\u001b[39mshots, trainable_params\u001b[38;5;241m=\u001b[39mtape\u001b[38;5;241m.\u001b[39mtrainable_params\n\u001b[1;32m     86\u001b[0m     )\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/transforms/convert_to_numpy_parameters.py:30\u001b[0m, in \u001b[0;36m_convert_op_to_numpy_data\u001b[0;34m(op)\u001b[0m\n\u001b[1;32m     28\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m op\n\u001b[1;32m     29\u001b[0m \u001b[38;5;66;03m# Use operator method to change parameters when it become available\u001b[39;00m\n\u001b[0;32m---> 30\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mqml\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mops\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfunctions\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbind_new_parameters\u001b[49m\u001b[43m(\u001b[49m\u001b[43mop\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmath\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43munwrap\u001b[49m\u001b[43m(\u001b[49m\u001b[43mop\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdata\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/functools.py:909\u001b[0m, in \u001b[0;36msingledispatch.<locals>.wrapper\u001b[0;34m(*args, **kw)\u001b[0m\n\u001b[1;32m    905\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m args:\n\u001b[1;32m    906\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mfuncname\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m requires at least \u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m    907\u001b[0m                     \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m1 positional argument\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m--> 909\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mdispatch\u001b[49m\u001b[43m(\u001b[49m\u001b[43margs\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[38;5;18;43m__class__\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkw\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/ops/functions/bind_new_parameters.py:50\u001b[0m, in \u001b[0;36mbind_new_parameters\u001b[0;34m(op, params)\u001b[0m\n\u001b[1;32m     35\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Create a new operator with updated parameters\u001b[39;00m\n\u001b[1;32m     36\u001b[0m \n\u001b[1;32m     37\u001b[0m \u001b[38;5;124;03mThis function takes an :class:`~.Operator` and new parameters as input and\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     47\u001b[0m \u001b[38;5;124;03m    .Operator: New operator with updated parameters\u001b[39;00m\n\u001b[1;32m     48\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m     49\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 50\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m op\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m(\u001b[38;5;241m*\u001b[39mparams, wires\u001b[38;5;241m=\u001b[39m\u001b[43mop\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mwires\u001b[49m, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mcopy\u001b[38;5;241m.\u001b[39mdeepcopy(op\u001b[38;5;241m.\u001b[39mhyperparameters))\n\u001b[1;32m     51\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m (\u001b[38;5;167;01mTypeError\u001b[39;00m, \u001b[38;5;167;01mValueError\u001b[39;00m):\n\u001b[1;32m     52\u001b[0m     \u001b[38;5;66;03m# operation is doing something different with its call signature.\u001b[39;00m\n\u001b[1;32m     53\u001b[0m     new_op \u001b[38;5;241m=\u001b[39m copy\u001b[38;5;241m.\u001b[39mdeepcopy(op)\n",
-      "File \u001b[0;32m~/anaconda3/envs/my_env/lib/python3.11/site-packages/pennylane/operation.py:1376\u001b[0m, in \u001b[0;36mOperator.wires\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   1373\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_check_batching()\n\u001b[1;32m   1374\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_batch_size\n\u001b[0;32m-> 1376\u001b[0m \u001b[38;5;129m@property\u001b[39m\n\u001b[1;32m   1377\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mwires\u001b[39m(\u001b[38;5;28mself\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Wires:\n\u001b[1;32m   1378\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Wires that the operator acts on.\u001b[39;00m\n\u001b[1;32m   1379\u001b[0m \n\u001b[1;32m   1380\u001b[0m \u001b[38;5;124;03m    Returns:\u001b[39;00m\n\u001b[1;32m   1381\u001b[0m \u001b[38;5;124;03m        Wires: wires\u001b[39;00m\n\u001b[1;32m   1382\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[1;32m   1383\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_wires\n",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import math\n",
@@ -223,11 +147,9 @@
     "n_qubits      = 5      # número de qubits (e de features por gerador)\n",
     "q_depth       = 6      # profundidade do circuito\n",
     "n_generators  = 8      # quantos “patches” quânticos → 40 dims\n",
-    "num_iter      = 500    # iterações de treino\n",
     "\n",
     "# ——— Dispositivo GPU ———\n",
     "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
-    "print(device)\n",
     "if device.type == 'cuda':\n",
     "    torch.cuda.empty_cache()\n",
     "\n",
@@ -245,17 +167,6 @@
     "scaled     = scale_data(flat_imgs, [0, 1])\n",
     "pca        = PCA(n_components=pca_dims)\n",
     "pca_data   = pca.fit_transform(scaled)\n",
-    "\n",
-    "# mantém os dados em CPU (tensores “normais”)\n",
-    "cpu_tensor_data = torch.from_numpy(scale_data(pca_data)).float()\n",
-    "\n",
-    "dataloader_pca = DataLoader(\n",
-    "    cpu_tensor_data,\n",
-    "    batch_size=batch_size,\n",
-    "    shuffle=True,\n",
-    "    drop_last=True,\n",
-    "    pin_memory=True,   # só pin na CPU; nunca pin tensores CUDA\n",
-    ")\n",
     "\n",
     "# ——— Circuito quântico ———\n",
     "dev = qml.device(\"lightning.qubit\", wires=n_qubits)\n",
@@ -320,59 +231,7 @@
     "            images[:, start:start + n_qubits] = patches\n",
     "\n",
     "        return images\n",
-    "\n",
-    "# ——— Instâncias e Otimizadores ———\n",
-    "D = Discriminator().to(device)\n",
-    "G = QuantumGenerator(n_generators).to(device)\n",
-    "\n",
-    "criterion = nn.BCELoss()\n",
-    "optD      = optim.SGD(D.parameters(), lr=1e-2)\n",
-    "optG      = optim.SGD(G.parameters(), lr=3e-1)\n",
-    "\n",
-    "# ——— Loop de Treino (GPU) ———\n",
-    "total_start = time.time()\n",
-    "for it in range(1, num_iter + 1):\n",
-    "    iter_start = time.time()\n",
-    "\n",
-    "    for real in dataloader_pca:\n",
-    "        # real sai do DataLoader em CPU, já como pinned tensor\n",
-    "        real   = real.to(device, non_blocking=True)\n",
-    "        b_size = real.size(0)\n",
-    "        real_lbl = torch.ones((b_size, 1), device=device)\n",
-    "        fake_lbl = torch.zeros((b_size, 1), device=device)\n",
-    "\n",
-    "        noise = torch.rand(b_size, n_qubits, device=device) * (math.pi / 2)\n",
-    "        fake  = G(noise)\n",
-    "\n",
-    "        # treina Discriminador\n",
-    "        optD.zero_grad()\n",
-    "        loss_D = criterion(D(real), real_lbl) + criterion(D(fake.detach()), fake_lbl)\n",
-    "        loss_D.backward()\n",
-    "        optD.step()\n",
-    "\n",
-    "        # treina Gerador\n",
-    "        optG.zero_grad()\n",
-    "        loss_G = criterion(D(fake), real_lbl)\n",
-    "        loss_G.backward()\n",
-    "        optG.step()\n",
-    "\n",
-    "    elapsed = time.time() - iter_start\n",
-    "    print(f\"Iter {it}/{num_iter}: Loss D={loss_D.item():.3f}, \"\n",
-    "          f\"Loss G={loss_G.item():.3f} — {elapsed:.2f}s\")\n",
-    "\n",
-    "    if it % 50 == 0:\n",
-    "        with torch.no_grad():\n",
-    "            eval_noise = torch.rand(8, n_qubits, device=device) * (math.pi / 2)\n",
-    "            samples    = G(eval_noise).cpu()\n",
-    "        fig, axs = plt.subplots(1, 8, figsize=(16, 2))\n",
-    "        for ax, samp in zip(axs, samples):\n",
-    "            ax.plot(samp.numpy())\n",
-    "            ax.axis('off')\n",
-    "        plt.tight_layout()\n",
-    "        plt.show()\n",
-    "\n",
-    "total_time = time.time() - total_start\n",
-    "print(f\"Tempo total de treinamento: {total_time:.2f}s\")\n"
+    "\n"
    ]
   },
   {
@@ -385,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,27 +308,14 @@
     "    print(f\"Training completed in {total_time:.2f}s\")\n",
     "    return hist_D, hist_G\n",
     "\n",
-    "# Exemplo de uso:\n",
-    "# hist_D, hist_G = train_quantum_gan(dataloader_pca, G, D, epochs=50, device=device)\n"
+    "# Exemplo de uso:\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'scale_data' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[6]\u001b[39m\u001b[32m, line 8\u001b[39m\n\u001b[32m      5\u001b[39m labels = train_dataset.labels \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(train_dataset, \u001b[33m\"\u001b[39m\u001b[33mlabels\u001b[39m\u001b[33m\"\u001b[39m) \u001b[38;5;28;01melse\u001b[39;00m train_dataset.targets\n\u001b[32m      7\u001b[39m \u001b[38;5;66;03m# Escala e converte o PCA já treinado (pca_data) para Tensor CPU\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m8\u001b[39m scaled_pca_np = \u001b[43mscale_data\u001b[49m(pca_data)                            \u001b[38;5;66;03m# shape (N, 40)\u001b[39;00m\n\u001b[32m      9\u001b[39m tensor_pca     = torch.from_numpy(scaled_pca_np).float()        \u001b[38;5;66;03m# Tensor CPU\u001b[39;00m\n\u001b[32m     11\u001b[39m \u001b[38;5;66;03m# Índices para cada classe\u001b[39;00m\n",
-      "\u001b[31mNameError\u001b[39m: name 'scale_data' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from torch.utils.data import DataLoader\n",
     "\n",


### PR DESCRIPTION
## Summary
- Remove obsolete subset_by_label cell and simplified training loop from `mosaiq_gan_medmnist.ipynb`.
- Add setup cell that defines preprocessing, quantum circuit, and model classes without executing training.
- Retain only class-specific training using dedicated loaders and `train_quantum_gan` helper.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a9b5ee570c83318d1bc4d51a8b5fd0